### PR TITLE
feat: Implement Pinfu and Toitoi yaku detection (Phase 3.1 PR2)

### DIFF
--- a/tests/FunctionalDddMahjong.Domain.Tests/YakuTests.fs
+++ b/tests/FunctionalDddMahjong.Domain.Tests/YakuTests.fs
@@ -31,9 +31,20 @@ module YakuTests =
 
     [<Fact>]
     let ``Yaku types should have correct properties`` () =
+        // Tanyao
         Assert.Equal("断么九", getName Tanyao)
         Assert.Equal(1, getHan Tanyao)
         Assert.Equal("All Simples", getEnglishName Tanyao)
+
+        // Pinfu
+        Assert.Equal("平和", getName Pinfu)
+        Assert.Equal(1, getHan Pinfu)
+        Assert.Equal("All Sequences", getEnglishName Pinfu)
+
+        // Toitoi
+        Assert.Equal("対々和", getName Toitoi)
+        Assert.Equal(2, getHan Toitoi)
+        Assert.Equal("All Triplets", getEnglishName Toitoi)
 
     [<Fact>]
     let ``tryCreateWinningHand should return None for waiting hand`` () =
@@ -112,3 +123,85 @@ module YakuTests =
         match result with
         | None -> Assert.True(true)
         | Some _ -> Assert.True(false, "Should not create WinningHand from non-winning hand")
+
+    // ピンフのテストケース
+    [<Theory>]
+    [<InlineData("1m,2m,3m,4p,5p,6p,7s,8s,9s,2m,3m,4m,5p,5p")>] // 順子4つ + 数牌の雀頭
+    [<InlineData("2m,3m,4m,3p,4p,5p,6p,7p,8p,4s,5s,6s,7s,7s")>] // 順子4つ + 数牌の雀頭（中張牌）
+    [<InlineData("1p,2p,3p,4p,5p,6p,7p,8p,9p,1s,2s,3s,2m,2m")>] // 清一色の順子 + 数牌の雀頭
+    let ``checkPinfu should accept valid pinfu hand`` (tileString: string) =
+        let tileStrings =
+            tileString.Split(',') |> Array.toList
+
+        let hand =
+            createReadyHand (createTiles tileStrings)
+
+        match tryCreateWinningHand hand with
+        | Some winningHand ->
+            let result = checkPinfu winningHand
+
+            match result with
+            | Some Pinfu -> Assert.True(true)
+            | None -> Assert.True(false, "Should accept valid pinfu hand")
+        | None -> Assert.True(false, "Should be a winning hand")
+
+    [<Theory>]
+    [<InlineData("1m,2m,3m,4p,5p,6p,7s,7s,7s,2m,3m,4m,5p,5p")>] // 刻子を含む
+    [<InlineData("1m,2m,3m,4p,5p,6p,7s,8s,9s,2m,3m,4m,E,E")>] // 字牌の雀頭
+    [<InlineData("2m,2m,2m,5p,5p,5p,8s,8s,8s,3m,3m,3m,7p,7p")>] // 全て刻子（トイトイ）
+    let ``checkPinfu should reject invalid pinfu hand`` (tileString: string) =
+        let tileStrings =
+            tileString.Split(',') |> Array.toList
+
+        let hand =
+            createReadyHand (createTiles tileStrings)
+
+        match tryCreateWinningHand hand with
+        | Some winningHand ->
+            let result = checkPinfu winningHand
+
+            match result with
+            | None -> Assert.True(true)
+            | Some _ -> Assert.True(false, "Should reject invalid pinfu hand")
+        | None -> Assert.True(false, "Should be a winning hand")
+
+    // トイトイのテストケース
+    [<Theory>]
+    [<InlineData("2m,2m,2m,5p,5p,5p,8s,8s,8s,3m,3m,3m,7p,7p")>] // 刻子4つ + 雀頭
+    [<InlineData("1m,1m,1m,9p,9p,9p,E,E,E,S,S,S,W,W")>] // 么九牌の刻子も含む
+    [<InlineData("4s,4s,4s,5s,5s,5s,6s,6s,6s,7s,7s,7s,8s,8s")>] // 清一色の刻子
+    let ``checkToitoi should accept valid toitoi hand`` (tileString: string) =
+        let tileStrings =
+            tileString.Split(',') |> Array.toList
+
+        let hand =
+            createReadyHand (createTiles tileStrings)
+
+        match tryCreateWinningHand hand with
+        | Some winningHand ->
+            let result = checkToitoi winningHand
+
+            match result with
+            | Some Toitoi -> Assert.True(true)
+            | None -> Assert.True(false, "Should accept valid toitoi hand")
+        | None -> Assert.True(false, "Should be a winning hand")
+
+    [<Theory>]
+    [<InlineData("1m,2m,3m,4p,5p,6p,7s,8s,9s,2m,3m,4m,5p,5p")>] // ピンフ（全て順子）
+    [<InlineData("1m,2m,3m,5p,5p,5p,7s,8s,9s,2m,3m,4m,3p,3p")>] // 順子3つ + 刻子1つ
+    [<InlineData("2m,2m,2m,3m,4m,5m,6p,7p,8p,7s,8s,9s,E,E")>] // 刻子1つ + 順子3つ
+    let ``checkToitoi should reject hand with sequences`` (tileString: string) =
+        let tileStrings =
+            tileString.Split(',') |> Array.toList
+
+        let hand =
+            createReadyHand (createTiles tileStrings)
+
+        match tryCreateWinningHand hand with
+        | Some winningHand ->
+            let result = checkToitoi winningHand
+
+            match result with
+            | None -> Assert.True(true)
+            | Some _ -> Assert.True(false, "Should reject toitoi hand with sequences")
+        | None -> Assert.True(false, "Should be a winning hand")


### PR DESCRIPTION
## Summary
- Implement Pinfu (平和/All Sequences) detection with simplified rules
- Implement Toitoi (対々和/All Triplets) detection
- Add comprehensive test coverage for both yaku

## Implementation Details

### Pinfu (平和) - Simplified Version
- Requires all 4 melds to be sequences
- Requires pair to be numeric tiles (not honor tiles)
- Note: This is a simplified version without waiting pattern consideration

### Toitoi (対々和)
- Requires all 4 melds to be triplets
- No restrictions on pair composition

## Test Coverage
- Added 12 new test cases (6 for each yaku)
- All 201 tests passing
- Code formatting verified with Fantomas

## Technical Approach
- Pattern matching on Meld discriminated union
- Functional composition for detection logic
- Maintained type safety and pure functions throughout

🤖 Generated with [Claude Code](https://claude.ai/code)