### PR TITLE
feat: Implement Reach domain types for Phase 5.2

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -124,10 +124,12 @@
 - [x] 純正九蓮宝燈対応（9種全待ち）
 - [x] MeldDecomposition重複除去による性能最適化
 
-### 5.2 リーチドメインの実装
-- [ ] ReachContext型の定義（プレイヤー点数、ゲーム段階、リーチ状態）
-- [ ] ReachError型の定義（ドメイン特化エラー）
-- [ ] ReachDeclaration型の定義（宣言結果）
+### 5.2 リーチドメインの実装 ✅
+- [x] ReachContext型の定義（プレイヤー点数、ゲーム段階、リーチ状態）
+- [x] ReachError型の定義（ドメイン特化エラー）
+- [x] ReachDeclaration型の定義（宣言結果）
+- [x] Turn型とScore型のValue Object実装（制約付き）
+- [x] 標準Result型による型安全なエラーハンドリング設計
 
 ### 5.3 Railway-Oriented Programming の実践
 - [ ] リーチ宣言バリデーションパイプラインの実装

--- a/src/FunctionalDddMahjong.Domain/FunctionalDddMahjong.Domain.fsproj
+++ b/src/FunctionalDddMahjong.Domain/FunctionalDddMahjong.Domain.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="TenpaiAnalyzer.fs" />
     <Compile Include="Yaku.fs" />
     <Compile Include="YakuAnalyzer.fs" />
+    <Compile Include="Reach.fs" />
   </ItemGroup>
 
 </Project>

--- a/src/FunctionalDddMahjong.Domain/Reach.fs
+++ b/src/FunctionalDddMahjong.Domain/Reach.fs
@@ -1,0 +1,51 @@
+namespace FunctionalDddMahjong.Domain
+
+/// 巡目を表現するValue Object（1-18の制約）
+type Turn = private Turn of int
+
+module Turn =
+    let create turn =
+        if turn >= 1 && turn <= 18 then
+            Ok(Turn turn)
+        else
+            Error "Turn must be between 1 and 18"
+
+    let value (Turn turn) = turn
+
+/// 点数を表現するValue Object（0以上の制約）
+type Score = private Score of int
+
+module Score =
+    let create score =
+        if score >= 0 then
+            Ok(Score score)
+        else
+            Error "Score must be non-negative"
+
+    let value (Score score) = score
+
+/// プレイヤーのリーチ状態を表現する型
+type ReachStatus =
+    | NotReached // リーチしていない
+    | AlreadyReached // 既にリーチ済み
+
+/// リーチ宣言に必要なゲーム状況を表現する型
+type ReachContext =
+    { PlayerScore: Score // プレイヤーの現在点数
+      CurrentTurn: Turn // 現在の巡目
+      ReachStatus: ReachStatus } // 現在のリーチ状態
+
+/// リーチ宣言時のドメイン特化エラーを表現する型
+type ReachError =
+    | NotTenpai // テンパイしていない
+    | InsufficientScore // 点数不足（1000点未満）
+    | TooLateInGame // ゲーム終盤でのリーチ制限（16巡目以降）
+    | AlreadyReached // 既にリーチ済み
+
+/// リーチの種類を表現する型
+type ReachResult =
+    | Reach // 通常リーチ（1翻）
+    | DoubleReach // ダブルリーチ（2翻）
+
+/// リーチ宣言の結果を表現する型（標準Result型を使用）
+type ReachDeclaration = Result<ReachResult * Score, ReachError>


### PR DESCRIPTION
## Summary
- Implement comprehensive Reach domain type definitions for Phase 5.2
- Add Turn and Score Value Objects with validation constraints (1-18 turns, non-negative scores)
- Define ReachContext, ReachError, ReachResult, and ReachDeclaration types
- Use standard Result type for railway-oriented programming preparation

## Test plan
- [x] Code compiles successfully
- [x] All existing tests pass (279 tests)
- [x] Code formatting passes fantomas checks
- [x] Build succeeds with no warnings

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced value objects and types for the "Reach" mechanic in Mahjong, including turn and score constraints.
  * Added detailed error handling for reach declaration scenarios.
  * Defined structures to represent reach status, context, and results.

* **Documentation**
  * Updated the todo list to reflect completed tasks related to the reach domain implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->