### PR TITLE
Phase 7.1 PR1: Add winning hand check API project and DTO definitions

### DIFF
--- a/FunctionalDddMahjong.sln
+++ b/FunctionalDddMahjong.sln
@@ -23,6 +23,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FunctionalDddMahjong.Shared
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FunctionalDddMahjong.Workflows.Tests", "tests\FunctionalDddMahjong.Workflows.Tests\FunctionalDddMahjong.Workflows.Tests.fsproj", "{CB6B821A-BA09-4FF2-ADE0-21A4FC1517A2}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FunctionalDddMahjong.Api", "src\FunctionalDddMahjong.Api\FunctionalDddMahjong.Api.fsproj", "{528FBCC6-6CE0-4E62-8EF3-DFDD5078EEBD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -64,6 +66,10 @@ Global
 		{CB6B821A-BA09-4FF2-ADE0-21A4FC1517A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CB6B821A-BA09-4FF2-ADE0-21A4FC1517A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CB6B821A-BA09-4FF2-ADE0-21A4FC1517A2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{528FBCC6-6CE0-4E62-8EF3-DFDD5078EEBD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{528FBCC6-6CE0-4E62-8EF3-DFDD5078EEBD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{528FBCC6-6CE0-4E62-8EF3-DFDD5078EEBD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{528FBCC6-6CE0-4E62-8EF3-DFDD5078EEBD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{39D5F93C-7FD2-486C-84BD-18DA77F4DDCB} = {F675E864-73ED-4204-8FF0-B1F861AABBCB}
@@ -74,5 +80,6 @@ Global
 		{9F6BCD1A-877E-4B7F-B58A-4FA9FBC0BD62} = {F675E864-73ED-4204-8FF0-B1F861AABBCB}
 		{BAAAC614-B95B-49A0-923C-9CF6816DB0B0} = {F52C74CC-248B-45EA-B3AD-94C303392B96}
 		{CB6B821A-BA09-4FF2-ADE0-21A4FC1517A2} = {F52C74CC-248B-45EA-B3AD-94C303392B96}
+		{528FBCC6-6CE0-4E62-8EF3-DFDD5078EEBD} = {F675E864-73ED-4204-8FF0-B1F861AABBCB}
 	EndGlobalSection
 EndGlobal

--- a/src/FunctionalDddMahjong.Api/Dto.fs
+++ b/src/FunctionalDddMahjong.Api/Dto.fs
@@ -1,0 +1,39 @@
+namespace FunctionalDddMahjong.Api
+
+/// DTOs for the winning hand check API
+/// Request to check if a hand is winning
+type CheckWinningHandRequest =
+    {
+        /// List of tile strings (e.g., ["1m", "2m", "3m", ...])
+        /// Must contain exactly 14 tiles
+        tiles: string list
+    }
+
+/// Information about a detected yaku (winning pattern)
+type YakuInfo =
+    {
+        /// Internal name of the yaku (e.g., "Tanyao")
+        name: string
+
+        /// Display name in Japanese (e.g., "タンヤオ")
+        displayName: string
+
+        /// Number of han (points) for this yaku
+        han: int
+
+        /// Description of the yaku
+        description: string
+    }
+
+/// Response from the winning hand check
+type CheckWinningHandResponse =
+    {
+        /// Whether the hand is a winning hand
+        isWinningHand: bool
+
+        /// List of detected yaku (empty if not winning)
+        detectedYaku: YakuInfo list
+
+        /// Total han count (0 if not winning)
+        totalHan: int
+    }

--- a/src/FunctionalDddMahjong.Api/FunctionalDddMahjong.Api.fsproj
+++ b/src/FunctionalDddMahjong.Api/FunctionalDddMahjong.Api.fsproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Dto.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FunctionalDddMahjong.SharedKernel\FunctionalDddMahjong.SharedKernel.fsproj" />
+    <ProjectReference Include="..\FunctionalDddMahjong.Domain\FunctionalDddMahjong.Domain.fsproj" />
+    <ProjectReference Include="..\FunctionalDddMahjong.DomainServices\FunctionalDddMahjong.DomainServices.fsproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- Create new FunctionalDddMahjong.Api project for API layer implementation
- Define DTOs for winning hand check API endpoint
- Set up proper project references and dependencies

## Changes
- **New project**: `FunctionalDddMahjong.Api`
  - F# library project in `src/FunctionalDddMahjong.Api/`
  - References Domain, DomainServices, and SharedKernel projects

- **DTO definitions** in `Dto.fs`:
  - `CheckWinningHandRequest`: Accepts 14 tile strings for winning hand validation
  - `YakuInfo`: Contains yaku information (internal name, display name, han count, description)
  - `CheckWinningHandResponse`: Returns validation result with detected yaku and total han

## Test Results
- ✅ All 309 existing tests passing
- ✅ Build successful
- ✅ Code formatted with Fantomas

## Next Steps
- PR2: Implement input parsing and validation
- PR3: Implement domain processing and output conversion

Part of Phase 7.1: API Layer Implementation

🤖 Generated with [Claude Code](https://claude.ai/code)